### PR TITLE
Fix for disablescroll not working

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -103,7 +103,7 @@ const MicroModal = (() => {
 
     scrollBehaviour (toggle) {
       if (!this.config.disableScroll) return
-      const body = document.querySelector('body')
+      const body = document.querySelector('html')
       switch (toggle) {
         case 'enable':
           Object.assign(body.style, { overflow: '' })


### PR DESCRIPTION
Fix for `disablescroll` not working.
Selecting `html` instead of `body` in the selector will work.